### PR TITLE
Fix missing pip on some systems

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,9 @@ def run_cmd(cmd: str, env=None) -> None:
 
 
 def main() -> None:
-    run_cmd("pip install -q pipenv cookiecutter")
+    run_cmd("python3 -m pip install -q pipenv cookiecutter")
     run_cmd(f"cookiecutter {TEMPLATE_REPO_URL}")
+    run_cmd("python3 -m pip uninstall -y -q cookiecutter")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There's only python3 and pip3 on Mac OS 12, so the setup does not work there.

Use python3 -m pip to support this case.

Also cleanup cookiecutter after use.