### PR TITLE
Fix error while locating features directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,10 @@ def run_command(cmd: str, env: Optional[dict] = None):
 
 def main():
     run_command("python3 -m pip install -q pipenv cookiecutter~=2.1")
-    run_command(f"cookiecutter {TEMPLATE_REPO_URL}")
+    # force default config to prevent user config from breaking
+    # features rendering in post-generate hook
+    run_command(f"cookiecutter --default-config {TEMPLATE_REPO_URL}")
+
     run_command("python3 -m pip uninstall -y -q cookiecutter")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ def render_project_dir(request):
                 cookiecutter(
                     template=str(current_dir.parent),
                     no_input=True,
+                    default_config=True,
                     overwrite_if_exists=True,
                     accept_hooks=use_hooks,
                     output_dir=current_dir,


### PR DESCRIPTION
When cloning from repository, _template is set to repo URL in cookiecutter context. Thus, it cannot be used to locate local repo direcroty.

The only way so far is to use the directory from cookiecutter config. But to do it reliably, we need to force default config. Otherwise, user config could break this functionality.