### PR TITLE
Fix isort hook installation error

### DIFF
--- a/.github/workflows/codeqa.yml
+++ b/.github/workflows/codeqa.yml
@@ -8,12 +8,16 @@ jobs:
     container: python:3.10
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      # this fixes git permissions issue, see https://github.com/actions/checkout/issues/1048
+      - name: Resolve permissions issue for repo directory
+        run: "git config --system --add safe.directory ${GITHUB_WORKSPACE}"
 
       - name: Install pre-commit
         run: |
           pip install -q pre-commit pipenv
-          pre-commit install --install-hooks
+          pre-commit install
 
       - name: Run code QA tools from pre-commit hooks
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.9.3
+    rev: 5.12.0
     hooks:
       - id: isort
 

--- a/{{ cookiecutter.__project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.__project_slug }}/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.9.3
+    rev: 5.12.0
     hooks:
       - id: isort
 


### PR DESCRIPTION
isort hook install fails for versions below 5.12.0. Update the version accordingly.